### PR TITLE
Helper function name generation fails for Unicode argument in test function

### DIFF
--- a/nose_parameterized/parameterized.py
+++ b/nose_parameterized/parameterized.py
@@ -82,7 +82,7 @@ def parameterized(input):
     return parameterized_helper
 
 def to_safe_name(s):
-    return re.sub("[^a-zA-Z0-9_]", "", s)
+    return str(re.sub("[^a-zA-Z0-9_]", "", s))
 
 def parameterized_expand_helper(func_name, func, args):
     def parameterized_expand_helper_helper(self=()):


### PR DESCRIPTION
If a test function is decorated with `@parameterized.expand` and the first argument for the function is a Unicode object, the test fails:

```
# -*- encoding: utf-8 -*-

from nose_parameterized import parameterized
from unittest import TestCase

class Issue1TestCase(TestCase):
    @parameterized.expand([
        (u'ä', r"u'\xe4'"),
        (u'ö', r"u'\xf6'"),
    ])
    def test_unicode_repr(self, unicode_string, expected):
        self.assertEqual(expected, repr(unicode_string))


======================================================================
ERROR: Failure: TypeError (__name__ must be set to a string object)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "nose/loader.py", line 390, in loadTestsFromName
    addr.filename, addr.module)
  File "nose/importer.py", line 39, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "nose/importer.py", line 86, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "tests.py", line 7, in <module>
    class Issue1TestCase(TestCase):
  File "tests.py", line 10, in Issue1TestCase
    (u'ö', r"u'\xf6'"),
  File "nose_parameterized/parameterized.py", line 122, in parameterized_expand_wrapper
    new_func = parameterized_expand_helper(name, f, args)
  File "nose_parameterized/parameterized.py", line 92, in parameterized_expand_helper
    parameterized_expand_helper_helper.__name__ = func_name
TypeError: __name__ must be set to a string object
```
