### PR TITLE
Adding name argument to the expand documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ But ``nose-parameterized`` fixes that::
             ("integer", 1, 1.0),
             ("large fraction", 1.6, 1),
         ])
-        def test_floor(self, input, expected):
+        def test_floor(self, name, input, expected):
             assert_equal(math.floor(input), expected)
 
     $ nosetests -v test_math.py


### PR DESCRIPTION
I pasted this directly into a file and ran it, which failed with 
`TypeError: test_floor() takes exactly 3 arguments (4 given)`
and, stepping through the test, it seems like the first argument is the name of the test.
