### PR TITLE
Wrapping the standalone functions with functools.wraps

### DIFF
--- a/nose_parameterized/parameterized.py
+++ b/nose_parameterized/parameterized.py
@@ -230,7 +230,11 @@ class parameterized(object):
 
     @classmethod
     def param_as_standalone_func(cls, p, func, name):
-        standalone_func = lambda *a: func(*(a + p.args), **p.kwargs)
+
+        @wraps(func)
+        def standalone_func(*a):
+            return func(*(a + p.args), **p.kwargs)
+
         standalone_func.__name__ = name
         return standalone_func
 


### PR DESCRIPTION
Hi,

we use nose-parameterized a bit, and we also do some stuff where we add attributes to the functions that we pass into nose.

Unfortunately, the parameterized.expand method doesn't wrap the function, it just generates a lambda and gives it the correct name. Is it possible to have it use functools.wraps instead? That makes sure that attributes are passed through to child functions as well.

If this is ok, I'd like to add a test for this as well, but the testing process isn't clear to me. Can you point me to what I should do to add a regular unit test? Do I just use add a method to test.py?

Thanks!
