### PR TITLE
Adding ability to over-ride parameterized.expand test case naming scheme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,34 +153,31 @@ of the method name. For example, the test case above will generate the methods
 
 If you need to override the way ``@parameterized.expand`` names your new
 test case methods then supply a custom naming function and pass it in for the
-optional keyword arg ``name_func``.
-Your naming function must take in 3 parameters which wil get passed: the original
-test case name, the parameters, and the iteration number.  Your naming function
-can use (or ignore) any of these parameters and return any test method name you like.
+optional keyword arg ``testcase_func_name``.
+Your naming function must take in 3 parameters which will get passed: the original
+test function reference, the iteration number, and the parameters.  Your naming
+function can use (or ignore) any of these parameters and return any test method
+name you like, but you should make it unique otherwise earlier generated test
+methods will get overwritten and not get run.
 
 .. code:: python
 
     import unittest
     from nose_parameterized import parameterized, compat
 
-    def custom_naming_func(testcase_name, parameters, generator_num):
-        if len(parameters.args) > 0 and isinstance(parameters.args[0], compat.string_types):
-            return testcase_name + '_myseparator_' + \
-                re.sub("[^a-zA-Z0-9_]+", "_", parameters.args[0])
-        else:
-            raise Exception("Error: 'custom_naming_func()' requires string "
-                            "parameter for extending test name.")
+    def custom_naming_func(testcase_func, param_num, params):
+        return testcase_func.__name__ + "_" + str(params.args[0])
 
     class AddTestCase(unittest.TestCase):
         @parameterized.expand([
             ("abc", 2, 3, 5),
             ("xyz", 2, 3, 5),
-        ], name_func=custom_naming_func)
+        ], testcase_func_name=custom_naming_func)
         def test_add(self, _, a, b, expected):
             assert_equal(a + b, expected)
 
 The test case above will generate the methods
-``test_add_myseparator_abc`` and ``test_add_myseparator_xyz``.
+``test_add_abc`` and ``test_add_xyz``.
 
 The ``param(...)`` helper represents the parameters for one specific test case.
 It can be used to pass keyword arguments to test cases:

--- a/nose_parameterized/parameterized.py
+++ b/nose_parameterized/parameterized.py
@@ -195,7 +195,7 @@ class parameterized(object):
         return input_values
 
     @classmethod
-    def expand(cls, input, name_func=None):
+    def expand(cls, input, testcase_func_name=None):
         """ A "brute force" method of parameterizing test cases. Creates new
             test cases and injects them into the namespace that the wrapped
             function is being defined in. Useful for parameterizing tests in
@@ -220,9 +220,9 @@ class parameterized(object):
             get_input = cls.input_as_callable(input)
             for num, args in enumerate(get_input()):
                 p = param.from_decorator(args)
-                if name_func:
+                if testcase_func_name:
                     # Caller wants to over-ride default test case func/method naming scheme.
-                    name = name_func(base_name, p, num)
+                    name = testcase_func_name(f, num, p)
                 else:
                     name_suffix = "_%s" %(num, )
                     if len(p.args) > 0 and isinstance(p.args[0], compat.string_types):


### PR DESCRIPTION
Adding ability to over-ride parameterized.expand test case naming scheme through caller provided naming function.
The custom naming function now takes in 3 parameters: original test case name, parameters, and the iteration number (the num) value.
When I reviewed the code I realized that some caller might also want the iteration 'num'.
