### PR TITLE
Nominal source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include CHANGELOG.txt
+include LICENSE.txt


### PR DESCRIPTION
The current release tarball hosted on PyPI is cluttered with unnecessary files such as VCS filters and CI config scripts. This commit provides a `MANIFEST.in` file which produces a tarball with the nominal set of files to distribute.

By default, `README.rst` and the files composing the package will be included, on top of which I am adding the `LICENSE.txt` and `CHANGELOG.txt` files. Both are desirable from a Linux packaging perspective.