### PR TITLE
Made it so that parameterized raises a ValueError if the iterable is empty

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 0.6.2 (???)
     * Make sure that `setUp` and `tearDown` methods work correctly (#40)
+    * Made it so that a ValueError is raised when an empty iterable is used to parameterize
 
 0.6.1 (2017-03-21)
     * Rename package from nose-parameterized to parameterized. A

--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -320,9 +320,15 @@ class parameterized(object):
                     if test_self is not None:
                         delattr(test_cls, test_func.__name__)
                     wrapper.__doc__ = original_doc
+
         wrapper.parameterized_input = self.get_input()
+
+        if not wrapper.parameterized_input:
+            raise ValueError('Parameters iterable was empty')
+
         wrapper.parameterized_func = test_func
         test_func.__name__ = "_parameterized_original_%s" %(test_func.__name__, )
+
         return wrapper
 
     def param_as_nose_tuple(self, test_self, func, num, p):

--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -430,6 +430,10 @@ class parameterized(object):
             frame_locals = frame[0].f_locals
 
             paramters = cls.input_as_callable(input)()
+
+            if not paramters:
+                raise ValueError('input was empty')
+
             for num, p in enumerate(paramters):
                 name = name_func(f, num, p)
                 frame_locals[name] = cls.param_as_standalone_func(p, f, name)

--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -224,6 +224,17 @@ def test_helpful_error_on_empty_iterable_input():
         raise AssertionError("Expected exception not raised")
 
 
+try:
+    class ExpectErrorOnEmptyInput(TestCase):
+        @parameterized.expand([])
+        def test_expect_error(self):
+            pass
+except ValueError as e:
+    assert_contains(str(e), "input was empty")
+else:
+    raise AssertionError("Expected exception not raised")
+
+
 expect("generator", [
     "test_wrapped_iterable_input('foo')",
 ])

--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -214,6 +214,16 @@ def test_helpful_error_on_invalid_parameters():
     else:
         raise AssertionError("Expected exception not raised")
 
+
+def test_helpful_error_on_empty_iterable_input():
+    try:
+        parameterized([])(lambda: None)
+    except ValueError as e:
+        assert_contains(str(e), "Parameters iterable was empty")
+    else:
+        raise AssertionError("Expected exception not raised")
+
+
 expect("generator", [
     "test_wrapped_iterable_input('foo')",
 ])


### PR DESCRIPTION
When parameterizing tests it is very unlikely that you want an empty iterator. This has burnt me in the past where the parameters are programmatically generated, and there is some bug in the generation code. In this case then the failure is silent, since no tests will be run.