### PR TITLE
fix the order when number of cases exceeds 10

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 0.6.2 (???)
     * Make sure that `setUp` and `tearDown` methods work correctly (#40)
+    * Fix the order when number of cases exceeds 10
 
 0.6.1 (2017-03-21)
     * Rename package from nose-parameterized to parameterized. A

--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -426,7 +426,7 @@ class parameterized(object):
             paramters = cls.input_as_callable(input)()
             digit = len(str(len(paramters) - 1))
             for num, p in enumerate(paramters):
-                name = name_func(f, "{1:0>{0}}".format(digit, num), p)
+                name = name_func(f, "{num:0>{digit}}".format(digit=digit, num=num), p)
                 frame_locals[name] = cls.param_as_standalone_func(p, f, name)
                 frame_locals[name].__doc__ = doc_func(f, num, p)
 

--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -424,8 +424,9 @@ class parameterized(object):
             frame_locals = frame[0].f_locals
 
             paramters = cls.input_as_callable(input)()
+            digit = len(str(len(paramters) - 1))
             for num, p in enumerate(paramters):
-                name = name_func(f, num, p)
+                name = name_func(f, "{1:0>{0}}".format(digit, num), p)
                 frame_locals[name] = cls.param_as_standalone_func(p, f, name)
                 frame_locals[name].__doc__ = doc_func(f, num, p)
 

--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -307,10 +307,3 @@ cases_over_10 = [(i, i+1) for i in range(11)]
 @parameterized(cases_over_10)
 def test_cases_over_10(input, expected):
     assert_equal(input, expected-1)
-
-
-cases_over_100 = [(i, i+1) for i in range(101)]
-
-@parameterized(cases_over_100)
-def test_cases_over_100(input, expected):
-    assert_equal(input, expected-1)

--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -300,3 +300,17 @@ def test_short_repr(input, expected, n=6):
 def test_with_docstring(input):
     """ Docstring! """
     pass
+
+
+cases_over_10 = [(i, i+1) for i in range(11)]
+
+@parameterized(cases_over_10)
+def test_cases_over_10(input, expected):
+    assert_equal(input, expected-1)
+
+
+cases_over_100 = [(i, i+1) for i in range(101)]
+
+@parameterized(cases_over_100)
+def test_cases_over_100(input, expected):
+    assert_equal(input, expected-1)


### PR DESCRIPTION
When number of cases exceeds 10, the order of cases goes wrong.
For example:

``` python
class MyTest(unittest.TestCase):
    @parameterized.expand([
        (1, 1, 2),
        (2, 2, 4),
        (3, 3, 6),
        (4, 4, 8),
        (5, 5, 10),
        (6, 6, 12),
        (7, 7, 14),
        (8, 8, 16),
        (9, 9, 18),
        (10, 10, 20),
        (11, 11, 22)
    ])
    def test_add(self, a, b, c):
        self.assertEqual(a + b, c)
```
The order is `(1, 1, 2) (2, 2, 4) (11, 11, 22) (3, 3, 6) (4, 4, 8) (5, 5, 10) (6, 6, 12) (7, 7, 14) (8, 8, 16) (9, 9, 18) (10, 10, 20)`, because testMethod is `test_add_0, test_add_1, test_add_10, test_add_2...`
I change the name of testMethod to `test_add_00, test_add_01, test_add_02...`, so the order corrects now.
