### PR TITLE
Support mock.patch class decorator

### DIFF
--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -53,16 +53,14 @@ def reapply_patches_if_need(func):
         func = dummy_wrapper(func)
         tmp_patchings = func.patchings
         delattr(func, 'patchings')
-        for i, patch_obj in enumerate(tmp_patchings):
+        for _, patch_obj in enumerate(tmp_patchings):
             func = patch_obj.decorate_callable(func)
-
     return func
 
 
 def delete_patches_if_need(func):
     if hasattr(func, 'patchings'):
-        for _ in range(len(func.patchings)):
-            func.patchings.pop()
+        func.patchings[:] = []
 
 
 class param(_param):

--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -53,7 +53,7 @@ def reapply_patches_if_need(func):
         func = dummy_wrapper(func)
         tmp_patchings = func.patchings
         delattr(func, 'patchings')
-        for _, patch_obj in enumerate(tmp_patchings):
+        for patch_obj in tmp_patchings:
             func = patch_obj.decorate_callable(func)
     return func
 
@@ -449,9 +449,9 @@ class parameterized(object):
             paramters = cls.input_as_callable(input)()
             for num, p in enumerate(paramters):
                 name = name_func(f, num, p)
-                # If original function applied any patch, re-construct
-                # all patches on the just former decoration layer of
-                # param_as_standalone_func so as not to share
+                # If the original function has patches applied by 'mock.patch',
+                # re-construct all patches on the just former decoration layer
+                # of param_as_standalone_func so as not to share
                 # patch objects between new functions
                 nf = reapply_patches_if_need(f)
                 frame_locals[name] = cls.param_as_standalone_func(p, nf, name)

--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import inspect
+import mock
 from unittest import TestCase
 from nose.tools import assert_equal
 from nose.plugins.skip import SkipTest
@@ -99,6 +100,70 @@ def custom_naming_func(custom_tag):
         return testcase_func.__name__ + ('_%s_name_' % custom_tag) + str(param.args[0])
 
     return custom_naming_func
+
+
+@mock.patch("os.getpid")
+class TestParameterizedExpandWithMockPatchForClass(TestCase):
+    expect([
+        "test_one_function_patch_decorator('foo1', 'umask', 'getpid')",
+        "test_one_function_patch_decorator('foo0', 'umask', 'getpid')",
+        "test_one_function_patch_decorator(42, 'umask', 'getpid')"])
+
+    @parameterized.expand([(42, ), "foo0", param("foo1")])
+    @mock.patch("os.umask")
+    def test_one_function_patch_decorator(self, foo, mock_umask, mock_getpid):
+        missing_tests.remove("test_one_function_patch_decorator(%r, %r, %r)" %
+                             (foo, mock_umask._mock_name,
+                              mock_getpid._mock_name))
+
+    expect([
+        "test_multiple_function_patch_decorator"
+        "(42, 51, 'umask', 'fdopen', 'getpid')",
+        "test_multiple_function_patch_decorator"
+        "('foo0', 'bar0', 'umask', 'fdopen', 'getpid')",
+        "test_multiple_function_patch_decorator"
+        "('foo1', 'bar1', 'umask', 'fdopen', 'getpid')"])
+
+    @parameterized.expand([(42, 51), ("foo0", "bar0"), param("foo1", "bar1")])
+    @mock.patch("os.fdopen")
+    @mock.patch("os.umask")
+    def test_multiple_function_patch_decorator(self, foo, bar, mock_umask,
+                                               mock_fdopen, mock_getpid):
+        missing_tests.remove("test_multiple_function_patch_decorator"
+                             "(%r, %r, %r, %r, %r)" %
+                             (foo, bar, mock_umask._mock_name,
+                              mock_fdopen._mock_name, mock_getpid._mock_name))
+
+
+class TestParameterizedExpandWithNoMockPatchForClass(TestCase):
+    expect([
+        "test_one_function_patch_decorator('foo1', 'umask')",
+        "test_one_function_patch_decorator('foo0', 'umask')",
+        "test_one_function_patch_decorator(42, 'umask')"])
+
+    @parameterized.expand([(42, ), "foo0", param("foo1")])
+    @mock.patch("os.umask")
+    def test_one_function_patch_decorator(self, foo, mock_umask):
+        missing_tests.remove("test_one_function_patch_decorator(%r, %r)" %
+                             (foo, mock_umask._mock_name))
+
+    expect([
+        "test_multiple_function_patch_decorator"
+        "(42, 51, 'umask', 'fdopen')",
+        "test_multiple_function_patch_decorator"
+        "('foo0', 'bar0', 'umask', 'fdopen')",
+        "test_multiple_function_patch_decorator"
+        "('foo1', 'bar1', 'umask', 'fdopen')"])
+
+    @parameterized.expand([(42, 51), ("foo0", "bar0"), param("foo1", "bar1")])
+    @mock.patch("os.fdopen")
+    @mock.patch("os.umask")
+    def test_multiple_function_patch_decorator(self, foo, bar, mock_umask,
+                                               mock_fdopen):
+        missing_tests.remove("test_multiple_function_patch_decorator"
+                             "(%r, %r, %r, %r)" %
+                             (foo, bar, mock_umask._mock_name,
+                              mock_fdopen._mock_name))
 
 
 class TestParamerizedOnTestCase(TestCase):

--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -107,7 +107,8 @@ class TestParameterizedExpandWithMockPatchForClass(TestCase):
     expect([
         "test_one_function_patch_decorator('foo1', 'umask', 'getpid')",
         "test_one_function_patch_decorator('foo0', 'umask', 'getpid')",
-        "test_one_function_patch_decorator(42, 'umask', 'getpid')"])
+        "test_one_function_patch_decorator(42, 'umask', 'getpid')",
+    ])
 
     @parameterized.expand([(42, ), "foo0", param("foo1")])
     @mock.patch("os.umask")
@@ -122,7 +123,8 @@ class TestParameterizedExpandWithMockPatchForClass(TestCase):
         "test_multiple_function_patch_decorator"
         "('foo0', 'bar0', 'umask', 'fdopen', 'getpid')",
         "test_multiple_function_patch_decorator"
-        "('foo1', 'bar1', 'umask', 'fdopen', 'getpid')"])
+        "('foo1', 'bar1', 'umask', 'fdopen', 'getpid')",
+    ])
 
     @parameterized.expand([(42, 51), ("foo0", "bar0"), param("foo1", "bar1")])
     @mock.patch("os.fdopen")
@@ -139,7 +141,8 @@ class TestParameterizedExpandWithNoMockPatchForClass(TestCase):
     expect([
         "test_one_function_patch_decorator('foo1', 'umask')",
         "test_one_function_patch_decorator('foo0', 'umask')",
-        "test_one_function_patch_decorator(42, 'umask')"])
+        "test_one_function_patch_decorator(42, 'umask')",
+    ])
 
     @parameterized.expand([(42, ), "foo0", param("foo1")])
     @mock.patch("os.umask")
@@ -153,7 +156,8 @@ class TestParameterizedExpandWithNoMockPatchForClass(TestCase):
         "test_multiple_function_patch_decorator"
         "('foo0', 'bar0', 'umask', 'fdopen')",
         "test_multiple_function_patch_decorator"
-        "('foo1', 'bar1', 'umask', 'fdopen')"])
+        "('foo1', 'bar1', 'umask', 'fdopen')",
+    ])
 
     @parameterized.expand([(42, 51), ("foo0", "bar0"), param("foo1", "bar1")])
     @mock.patch("os.fdopen")

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=py{27,35,36,py}-{nose,nose2,pytest,unit,unit2}
 [testenv]
 deps=
     nose
+    mock
     nose2: nose2
     pytest: pytest>=2
     unit2: unittest2


### PR DESCRIPTION
Change so that parameterised.expand check function is decorated by mock.patch or not by the function object's property (patching). 
If the function is decorated by mock.patch, it try to re-decorate the function by mock.patch after decorate it with dummy decoration so as mock.patch to decorate the function be generated by parameterised.expand as a all different function, and then make original patching list empty not to be evaluated.
By doing this approach, this PR fixed issue #52 

If owner of parameterised module think it's reasonable to support mock.patch class decorator, I will write unit test for this PR.

Fixes #52 