### PR TITLE
@parameterized_class name function callback support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ matrix:
       python: "pypy"
     - env: "TOXENV=pypy-unit2"
       python: "pypy"
-install: pip install tox
+install: pip install tox==3.7.0
 script: tox

--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -452,12 +452,57 @@ def test_cases_over_10(input, expected):
 ])
 class TestParameterizedClass(TestCase):
     expect([
-        "TestParameterizedClass_0_foo:test_method_a('foo', 1, 2)",
-        "TestParameterizedClass_0_foo:test_method_b('foo', 1, 2)",
-        "TestParameterizedClass_1_bar:test_method_a('bar', 3, 0)",
-        "TestParameterizedClass_1_bar:test_method_b('bar', 3, 0)",
+        "TestParameterizedClass_0:test_method_a('foo', 1, 2)",
+        "TestParameterizedClass_0:test_method_b('foo', 1, 2)",
+        "TestParameterizedClass_1:test_method_a('bar', 3, 0)",
+        "TestParameterizedClass_1:test_method_b('bar', 3, 0)",
         "TestParameterizedClass_2:test_method_a(0, 1, 2)",
         "TestParameterizedClass_2:test_method_b(0, 1, 2)",
+    ])
+
+    def _assertions(self, test_name):
+        assert hasattr(self, "a")
+        assert_equal(self.b + self.c, 3)
+        missing_tests.remove("%s:%s(%r, %r, %r)" %(
+            self.__class__.__name__,
+            test_name,
+            self.a,
+            self.b,
+            self.c,
+        ))
+
+    def test_method_a(self):
+        self._assertions("test_method_a")
+
+    def test_method_b(self):
+        self._assertions("test_method_b")
+
+
+def custom_cls_naming_func(clsname, idx, attrs):
+    """
+    Custom class naming function for the form of parameterized_class that
+    takes a tuple of attributes, then a list of tuples of values
+    :param clsname: The original class that the decorator specialises
+    :param idx: the test index (starts at 0)
+    :param attrs: A list of dicts of attribute values
+    :return:
+    """
+    return "%s_%s_%s_%s" % (clsname.__name__, str(attrs[idx]['a']), str(attrs[idx]['b']), str(attrs[idx]['c']))
+
+
+@parameterized_class(("a", "b", "c"), [
+    ("foo", 1, 2),
+    ("bar", 3, 0),
+    (0, 1, 2),
+], classname_func=custom_cls_naming_func)
+class TestNamedParameterizedClass(TestCase):
+    expect([
+        "TestNamedParameterizedClass_foo_1_2:test_method_a('foo', 1, 2)",
+        "TestNamedParameterizedClass_foo_1_2:test_method_b('foo', 1, 2)",
+        "TestNamedParameterizedClass_bar_3_0:test_method_a('bar', 3, 0)",
+        "TestNamedParameterizedClass_bar_3_0:test_method_b('bar', 3, 0)",
+        "TestNamedParameterizedClass_0_1_2:test_method_a(0, 1, 2)",
+        "TestNamedParameterizedClass_0_1_2:test_method_b(0, 1, 2)",
     ])
 
     def _assertions(self, test_name):
@@ -486,6 +531,40 @@ class TestParameterizedClassDict(TestCase):
     expect([
         "TestParameterizedClassDict_0:test_method(1, 0)",
         "TestParameterizedClassDict_1:test_method(0, 1)",
+    ])
+
+    foo = 0
+    bar = 0
+
+    def test_method(self):
+        missing_tests.remove("%s:test_method(%r, %r)" %(
+            self.__class__.__name__,
+            self.foo,
+            self.bar,
+        ))
+
+
+def custom_cls_naming_dict_func(clsname, idx, attrs):
+    """
+    Custom class naming function for the form of parameterized_class that
+    takes a list of dictionaries containing attributes to override.
+    :param clsname: The original class that the decorator specialises
+    :param idx: the test index (starts at 0)
+    :param attrs: A list of dicts of attribute values
+    :return:
+    """
+    return "%s_%s_%s" % (clsname.__name__, str(attrs[idx].get('foo', 0)), str(attrs[idx].get('bar', 0)))
+
+
+@parameterized_class([
+    {"foo": 1},
+    {"bar": 1},
+], classname_func=custom_cls_naming_dict_func
+)
+class TestNamedParameterizedClassDict(TestCase):
+    expect([
+        "TestNamedParameterizedClassDict_1_0:test_method(1, 0)",
+        "TestNamedParameterizedClassDict_0_1:test_method(0, 1)",
     ])
 
     foo = 0


### PR DESCRIPTION
Hi. The @parameterized.expand decorator allows a callback function to be specified that generates the name of each test method that's generated for each tuple in the input data set list. This is fantastic - however I'm using the new @parameterized_class decorator which I noticed doesn't currently support a similar mechanism to set the generated class name. I've added support in this PR and added some tests to the unit tests file to demonstrate the use and test it. Is there anything else that you need me to add to this PR before it can be considered for merging in? Cheers, Duncan.