### PR TITLE
Add test for test mixins

### DIFF
--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -516,3 +516,35 @@ class TestParameterizedClassDict(TestCase):
             self.foo,
             self.bar,
         ))
+
+
+class TestMixin:
+    def test_method2(self):
+        missing_tests.remove("%s:test_method2(%r, %r)" %(
+            self.__class__.__name__,
+            self.foo,
+            self.bar,
+        ))
+
+
+@parameterized_class([
+    {"foo": 1},
+    {"bar": 1},
+])
+class TestParameterizedClassMixin(TestCase, TestMixin):
+    expect([
+        "TestParameterizedClassMixin_0:test_method(1, 0)",
+        "TestParameterizedClassMixin_1:test_method(0, 1)",
+        "TestParameterizedClassMixin_0:test_method2(1, 0)",
+        "TestParameterizedClassMixin_1:test_method2(0, 1)",
+    ])
+
+    foo = 0
+    bar = 0
+
+    def test_method(self):
+        missing_tests.remove("%s:test_method(%r, %r)" %(
+            self.__class__.__name__,
+            self.foo,
+            self.bar,
+        ))


### PR DESCRIPTION
Hey,

This PR adds a test showcasing an issue I found when trying to abstract some tests to a common base class.

It's somewhat related to #73, the problem being that `test_method2` is ran for the non-parameterized class, because its `__dict__` does not contain it.

The only solution I can think of is to recursively copy the base classes while pruning them of `test_` methods.

@wolever would you accept such a change? Do you think it's worth it?