### PR TITLE
Fix #85: setup.py updated to handle non-ascii characters in README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import io
 import os
 import sys
 
@@ -8,7 +9,7 @@ from setuptools import setup, find_packages
 os.chdir(os.path.dirname(sys.argv[0]) or ".")
 
 try:
-    long_description = open("README.rst", "U").read()
+    long_description = io.open("README.rst", "U", encoding="utf-8").read()
 except IOError:
     long_description = "See https://github.com/wolever/parameterized"
 


### PR DESCRIPTION
Another fix proposal for https://github.com/wolever/parameterized/issues/85 based on following posts:
1. Simplest, however it doesn't work for python 2.7: https://askubuntu.com/questions/611508/ubuntu-14-04-python-3-4-unicodedecodeerror
2. Use `io` instead of plain `open`: https://stackoverflow.com/questions/25049962/is-encoding-is-an-invalid-keyword-error-inevitable-in-python-2-x

