### PR TITLE
fix got an error message, lambda missing arguments while set skip_on_empty

### DIFF
--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -375,7 +375,7 @@ class parameterized(object):
                     "`parameterized([], skip_on_empty=True)` to skip "
                     "this test when the input is empty)"
                 )
-            wrapper = wraps(test_func)(lambda: skip_on_empty_helper())
+            wrapper = wraps(test_func)(lambda *args: skip_on_empty_helper())
 
         wrapper.parameterized_input = input
         wrapper.parameterized_func = test_func
@@ -491,7 +491,7 @@ class parameterized(object):
                         "`parameterized.expand([], skip_on_empty=True)` to skip "
                         "this test when the input is empty)"
                     )
-                return wraps(f)(lambda: skip_on_empty_helper())
+                return wraps(f)(lambda *args: skip_on_empty_helper())
 
             digits = len(str(len(paramters) - 1))
             for num, p in enumerate(paramters):


### PR DESCRIPTION
you can link this to issue [92](https://github.com/wolever/parameterized/issues/92)

fix got an error message, lambda missing arguments while set `skip_on_empty=True` but parameter list is empty and test function need arguments

----------------------------------------------------------------------
TypeError: <lambda>() takes 0 positional arguments but 1 was given