### PR TITLE
Issue #90: Port setup.py to Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ from setuptools import setup, find_packages
 os.chdir(os.path.dirname(sys.argv[0]) or ".")
 
 try:
-    long_description = open("README.rst", "U").read()
+    with open("README.rst") as fp:
+        long_description = fp.read()
 except IOError:
     long_description = "See https://github.com/wolever/parameterized"
 


### PR DESCRIPTION
Avoid "U" mode in open(). This flag was ignored since Python 3.0 and
now raises an error in Python 3.9:
https://bugs.python.org/issue37330

On Python 2, setup.py no longer replaces DOS (\r\n) and Mac (\r) with
Unix newline (\n). But it is not an issue in practice, since
README.rst uses Unix newline format (\n).

Fix also a ResourceWarning: use "with" context manager to ensure that
the file is closed. The warning was displayed when using
"python3 -Wd setup.py (...)".