### PR TITLE
Fix arguments to skip_on_empty helper

### DIFF
--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -503,7 +503,7 @@ class parameterized(object):
                         "`parameterized.expand([], skip_on_empty=True)` to skip "
                         "this test when the input is empty)"
                     )
-                return wraps(f)(lambda: skip_on_empty_helper())
+                return wraps(f)(skip_on_empty_helper)
 
             digits = len(str(len(parameters) - 1))
             for num, p in enumerate(parameters):


### PR DESCRIPTION
This commit will fix the arguments being passed to skip_on_empty_helper method. This was originally fixed in commit 6e80b2f68adecc6625cf4061d745aa196518b6aa.

However, the issue still persisted due to this missing change.

*Testing Done*: All the tests on CircleCI passed successfully.
https://app.circleci.com/pipelines/github/bhavyakjain/parameterized/1/workflows/81206f8c-0dfe-4cc1-9855-8a40d53ea0b2