### PR TITLE
Allow parameterized class to handle camel case test method names

### DIFF
--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -609,7 +609,7 @@ def parameterized_class(attrs, input_values=None, class_name_func=None, classnam
         # Address this by iterating over the base class and remove all test
         # methods.
         for method_name in list(base_class.__dict__):
-            if method_name.startswith("test_"):
+            if method_name.startswith("test"):
                 delattr(base_class, method_name)
         return base_class
 

--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -453,8 +453,10 @@ class TestParameterizedClass(TestCase):
     expect([
         "TestParameterizedClass_0_foo:test_method_a('foo', 1, 2)",
         "TestParameterizedClass_0_foo:test_method_b('foo', 1, 2)",
+        "TestParameterizedClass_0_foo:testCamelCaseMethodC('foo', 1, 2)",
         "TestParameterizedClass_1:test_method_a(0, 1, 2)",
         "TestParameterizedClass_1:test_method_b(0, 1, 2)",
+        "TestParameterizedClass_1:testCamelCaseMethodC(0, 1, 2)",
     ])
 
     def _assertions(self, test_name):
@@ -473,6 +475,9 @@ class TestParameterizedClass(TestCase):
 
     def test_method_b(self):
         self._assertions("test_method_b")
+
+    def testCamelCaseMethodC(self):
+        self._assertions("testCamelCaseMethodC")
 
 
 @parameterized_class(("a", ), [


### PR DESCRIPTION
Hi,
When parameterising a class with tests written with camel case names, the original base class doesn't have its test methods removed because they don't match the `if method_name.startswith("test_"):` evaluation. I only have limited influence over the naming conventions on the codebase I'm working on - can this evaluation be modified as per this PR? 

Tested here: https://app.circleci.com/pipelines/github/bobwalker99/parameterized?branch=class_test_names2 (couldn't get CircleCI to build retrospectively on the original branch (`class_test_names`)  so I built it on an identical branch `class_test_names2`.
