### PR TITLE
Replace description-file metadata key with description_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 universal=1
 
 [metadata]
-description-file=README.rst
+description_file=README.rst
 license_file=LICENSE.txt


### PR DESCRIPTION
When using the latest setuptools a warning is shown

```
/usr/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
```


This originates from https://github.com/pypa/setuptools/pull/2588