### PR TITLE
Added "is_parametrized" flag to the parametrized classes.

### DIFF
--- a/parameterized/parameterized.py
+++ b/parameterized/parameterized.py
@@ -614,6 +614,9 @@ def parameterized_class(attrs, input_values=None, class_name_func=None, classnam
         for method_name in list(base_class.__dict__):
             if method_name.startswith("test"):
                 delattr(base_class, method_name)
+
+        setattr(base_class, "is_parametrized", True)
+
         return base_class
 
     return decorator


### PR DESCRIPTION
In my project I need to recognize whether the `unittest.TestCase` is parametrized or not. The easiest way to do it is adding `is_parametrized` flag to the base class.