### PR TITLE
Fix unittest warning

### DIFF
--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -35,7 +35,7 @@ def assert_raises_regexp_decorator(expected_exception, expected_regexp):
     def func_decorator(func):
         @wraps(func)
         def wrapper(self, *args, **kwargs):
-            with self.assertRaisesRegexp(expected_exception, expected_regexp):
+            with self.assertRaisesRegex(expected_exception, expected_regexp):
                 func(self, *args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
Fix this warning:

```
/.../parameterized/test.py:38: DeprecationWarning: Please use assertRaisesRegex instead.
  with self.assertRaisesRegexp(expected_exception, expected_regexp):
```

The version ending “p” was deprecated in Python 3.2 and will be removed in 3.12: https://docs.python.org/dev/whatsnew/3.12.html#removed .