### PR TITLE
Use unittest for mock instead of the mock module

### DIFF
--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -2,9 +2,8 @@
 
 import inspect
 import sys
-import mock
 from functools import wraps
-from unittest import TestCase
+from unittest import mock, TestCase
 try:
     from nose.tools import assert_equal, assert_raises
 except ImportError:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist=pypy3-{nose,nose2,pytest3,unit,unit2},py{37,38,39}-{nose,nose2,pytest3,u
 [testenv]
 deps=
     nose
-    mock
     nose2: nose2
     pytest2: pytest>=2,<3
     pytest3: pytest>=3,<4


### PR DESCRIPTION
The unittest module has a mock object library since 3.3