### PR TITLE
Fix tests to handle Python 3.13 stripping indents from docstrings

### DIFF
--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -408,10 +408,16 @@ class TestParameterizedExpandDocstring(TestCase):
         """Documentation.
 
         More"""
-        self._assert_docstring(
-            "Documentation [with foo=%r].\n\n"
-            "        More" %(foo, )
-        )
+        if sys.version_info[:2] < (3, 13):
+            self._assert_docstring(
+                "Documentation [with foo=%r].\n\n"
+                "        More" %(foo, )
+            )
+        else:
+            self._assert_docstring(
+                "Documentation [with foo=%r].\n\n"
+                "More" %(foo, )
+            )
 
     @parameterized.expand([param("foo")])
     def test_unicode_docstring(self, foo):

--- a/parameterized/test.py
+++ b/parameterized/test.py
@@ -385,6 +385,8 @@ class TestParameterizedExpandDocstring(TestCase):
         actual_docstring = test_method.__doc__
         if rstrip:
             actual_docstring = actual_docstring.rstrip()
+        if sys.version_info[:2] >= (3, 13):
+            expected_docstring = inspect.cleandoc(expected_docstring)
         assert_equal(actual_docstring, expected_docstring)
 
     @parameterized.expand([param("foo")],
@@ -408,16 +410,10 @@ class TestParameterizedExpandDocstring(TestCase):
         """Documentation.
 
         More"""
-        if sys.version_info[:2] < (3, 13):
-            self._assert_docstring(
-                "Documentation [with foo=%r].\n\n"
-                "        More" %(foo, )
-            )
-        else:
-            self._assert_docstring(
-                "Documentation [with foo=%r].\n\n"
-                "More" %(foo, )
-            )
+        self._assert_docstring(
+            "Documentation [with foo=%r].\n\n"
+            "        More" %(foo, )
+        )
 
     @parameterized.expand([param("foo")])
     def test_unicode_docstring(self, foo):


### PR DESCRIPTION
https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes

https://github.com/python/cpython/issues/81283

You can reproduce the original failure and verify this change by running

```
tox -e py313-unit
```

but you will need to apply https://github.com/wolever/parameterized/pull/169 first.