### PR TITLE
Update license to SPDX standard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "parameterized"
 authors = [{name = "David Wolever", email = "david@wolever.net"}]
-license = {text = "FreeBSD"}
+license = {text = "bsd-2-clause-freebsd"}
 description = "Parameterized testing with any Python test framework"
 readme = "README.rst"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "parameterized"
 authors = [{name = "David Wolever", email = "david@wolever.net"}]
-license = {text = "bsd-2-clause-freebsd"}
+license = "bsd-2-clause-freebsd"
 description = "Parameterized testing with any Python test framework"
 readme = "README.rst"
 requires-python = ">=3.7"


### PR DESCRIPTION
Use the SPDX name to make sure no confusion can be. And PyPi can detect it

https://spdx.org/licenses/FreeBSD-DOC.html